### PR TITLE
fix on the results the keys features

### DIFF
--- a/dist/js/select2.full.js
+++ b/dist/js/select2.full.js
@@ -933,22 +933,26 @@ S2.define('select2/results',["./utils"], function (Utils) {
   };
 
   Results.prototype.highlightFirstItem = function () {
-    var options = this.results.querySelectorAll(
-      ".select2-results__option--selectable"
-    );
-    var selected = Array.prototype.filter.call(
-      options,
-      function (option) {
-        return option.classList.contains(
-          "select2-results__option--selected"
-        );
-      }
-    );
-    if (selected.length > 0) {
-      selected[0].dispatchEvent(new Event("mouseenter"));
-    } else if (options.length > 0) {
-      options[0].dispatchEvent(new Event("mouseenter"));
+    var options = this.results.querySelectorAll(".select2-results__option--selectable");
+
+    if (options.length === 0) {
+        return;
     }
+
+    var selected = Array.from(options).find(option =>
+        option.classList.contains("select2-results__option--selected")
+    );
+
+    var highlightTarget = selected || options[0];
+
+    // Ensure the target is visible before dispatching event
+    highlightTarget.scrollIntoView({ block: "nearest", inline: "nearest" });
+
+
+    highlightTarget.classList.add("select2-results__option--highlighted");
+    highlightTarget.setAttribute("aria-selected", "true");
+
+    highlightTarget.dispatchEvent(new Event("mouseenter", { bubbles: true }));
 
     this.ensureHighlightVisible();
   };
@@ -2159,7 +2163,6 @@ S2.define('select2/selection/search',["../utils", "../keys"], function (Utils, K
       if (evt.target === self.search) {
         evt.stopPropagation();
 
-        self.trigger("keypress", evt);
         self._keyUpPrevented = evt.defaultPrevented;
 
         if (evt.key === "Backspace" && self.search.value === "") {

--- a/dist/js/select2.js
+++ b/dist/js/select2.js
@@ -933,22 +933,26 @@ S2.define('select2/results',["./utils"], function (Utils) {
   };
 
   Results.prototype.highlightFirstItem = function () {
-    var options = this.results.querySelectorAll(
-      ".select2-results__option--selectable"
-    );
-    var selected = Array.prototype.filter.call(
-      options,
-      function (option) {
-        return option.classList.contains(
-          "select2-results__option--selected"
-        );
-      }
-    );
-    if (selected.length > 0) {
-      selected[0].dispatchEvent(new Event("mouseenter"));
-    } else if (options.length > 0) {
-      options[0].dispatchEvent(new Event("mouseenter"));
+    var options = this.results.querySelectorAll(".select2-results__option--selectable");
+
+    if (options.length === 0) {
+        return;
     }
+
+    var selected = Array.from(options).find(option =>
+        option.classList.contains("select2-results__option--selected")
+    );
+
+    var highlightTarget = selected || options[0];
+
+    // Ensure the target is visible before dispatching event
+    highlightTarget.scrollIntoView({ block: "nearest", inline: "nearest" });
+
+
+    highlightTarget.classList.add("select2-results__option--highlighted");
+    highlightTarget.setAttribute("aria-selected", "true");
+
+    highlightTarget.dispatchEvent(new Event("mouseenter", { bubbles: true }));
 
     this.ensureHighlightVisible();
   };
@@ -2159,7 +2163,6 @@ S2.define('select2/selection/search',["../utils", "../keys"], function (Utils, K
       if (evt.target === self.search) {
         evt.stopPropagation();
 
-        self.trigger("keypress", evt);
         self._keyUpPrevented = evt.defaultPrevented;
 
         if (evt.key === "Backspace" && self.search.value === "") {

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -98,22 +98,26 @@ define(["./utils"], function (Utils) {
   };
 
   Results.prototype.highlightFirstItem = function () {
-    var options = this.results.querySelectorAll(
-      ".select2-results__option--selectable"
-    );
-    var selected = Array.prototype.filter.call(
-      options,
-      function (option) {
-        return option.classList.contains(
-          "select2-results__option--selected"
-        );
-      }
-    );
-    if (selected.length > 0) {
-      selected[0].dispatchEvent(new Event("mouseenter"));
-    } else if (options.length > 0) {
-      options[0].dispatchEvent(new Event("mouseenter"));
+    var options = this.results.querySelectorAll(".select2-results__option--selectable");
+
+    if (options.length === 0) {
+        return;
     }
+
+    var selected = Array.from(options).find(option =>
+        option.classList.contains("select2-results__option--selected")
+    );
+
+    var highlightTarget = selected || options[0];
+
+    // Ensure the target is visible before dispatching event
+    highlightTarget.scrollIntoView({ block: "nearest", inline: "nearest" });
+
+
+    highlightTarget.classList.add("select2-results__option--highlighted");
+    highlightTarget.setAttribute("aria-selected", "true");
+
+    highlightTarget.dispatchEvent(new Event("mouseenter", { bubbles: true }));
 
     this.ensureHighlightVisible();
   };

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -83,7 +83,6 @@ define(["../utils", "../keys"], function (Utils, KEYS) {
       if (evt.target === self.search) {
         evt.stopPropagation();
 
-        self.trigger("keypress", evt);
         self._keyUpPrevented = evt.defaultPrevented;
 
         if (evt.key === "Backspace" && self.search.value === "") {


### PR DESCRIPTION
This pull request includes changes to improve the functionality of the Select2 library, specifically in the `results.js` and `search.js` files. The changes focus on enhancing the item highlighting logic and refining event handling.

Improvements to item highlighting:

* [`src/js/select2/results.js`](diffhunk://#diff-0d221431aac84fc52153cf5999d9e2fd472e89200729f711321af40a5ba01553L101-R120): Modified the `highlightFirstItem` method to streamline the selection process, ensure the target item is visible before dispatching the event, and improve accessibility by adding the `select2-results__option--highlighted` class and setting the `aria-selected` attribute.

Refinement of event handling:

* [`src/js/select2/selection/search.js`](diffhunk://#diff-08a0b7c0f2140d07a4f4801a4ed866009a1a0d128341d7c89e2007b60e64402aL86): Removed the unnecessary `keypress` trigger event in the search input event handler to prevent redundant event propagation.